### PR TITLE
Removed 4 unnecessary stubbings in TextCellTest.java

### DIFF
--- a/src/test/java/org/vandeseer/easytable/structure/cell/TextCellTest.java
+++ b/src/test/java/org/vandeseer/easytable/structure/cell/TextCellTest.java
@@ -96,7 +96,7 @@ public class TextCellTest {
 
     @Test
     public void getWidth_cellWithSpanningNoWrapping() {
-        prepareTwoSpanningColumnsOfSize(20f, 20f);
+        prepareTwoSpanningColumnsOfSize2(20f, 20f);
 
         final String text = "abc";
 
@@ -166,7 +166,6 @@ public class TextCellTest {
     }
 
     private TextCell prepareForTest(TextCell cell) {
-        when(row.getTable()).thenReturn(table);
         cell.setRow(row);
         cell.setColumn(column);
         return cell;
@@ -175,5 +174,8 @@ public class TextCellTest {
     private void setColumnWidthTo(float width) {
         when(column.getWidth()).thenReturn(width);
     }
-
+    
+    private void prepareTwoSpanningColumnsOfSize2(float sizeColumn1, float sizeColumn2) {
+        Column nextColumn = mock(Column.class);
+    }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 stubbing which is created in `TextCellTest.prepareForTest` but never executed.

2) 3 stubbings are created in `TextCellTest.prepareTwoSpanningColumnsOfSize`but never executed by the test `TextCellTest.getWidth_cellWithSpanningNoWrapping`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.